### PR TITLE
Format and mount external volumes to the instances in cloud-init

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Terraform module to setup all resources needed for an Elasticsearch cluster.
 *   \[`db_vl_name`\]: String(optional, default "/dev/xvdg"): Volume device name of the Elasticsearch data EBS volume.
 *   \[`elb_internal`\]: Bool(optional, default true): Whether the ELB should be internal only (not-public).
 *   \[`snapshot_s3_bucket_arn`\]: String(optional, default ""): The S3 bucket ARN where the ES snapshots will be stored, this is just to give the proper permissions to the EC2 instance profiles.
+*   \[`es_data_dir`\]: String(optional, default "/usr/share/elasticsearch/data/"): The directory where to mount the external volume, so this will be the directory where Elasticsearch will store the data.
 
 ## Output
 

--- a/main.tf
+++ b/main.tf
@@ -10,7 +10,7 @@ module "elk_instances" {
   instance_type          = "${var.instance_type}"
   subnets                = "${var.subnet_ids}"
   sgs                    = ["${aws_security_group.elk_sg.id}", "${var.sg_all_id}"]
-  user_data              = ["${data.template_cloudinit_config.instances_userdata.rendered}"]
+  user_data              = "${data.template_cloudinit_config.instances_userdata.*.rendered}"
 }
 
 module "elk_userdata" {

--- a/main.tf
+++ b/main.tf
@@ -9,8 +9,8 @@ module "elk_instances" {
   ami                    = "${var.ami}"
   instance_type          = "${var.instance_type}"
   subnets                = "${var.subnet_ids}"
-  sgs                    = [ "${aws_security_group.elk_sg.id}", "${var.sg_all_id}" ]
-  user_data              = [ "${module.elk_userdata.user_datas}" ]
+  sgs                    = ["${aws_security_group.elk_sg.id}", "${var.sg_all_id}"]
+  user_data              = ["${data.template_cloudinit_config.instances_userdata.rendered}"]
 }
 
 module "elk_userdata" {
@@ -19,6 +19,40 @@ module "elk_userdata" {
   customer            = "${var.project}"
   environment         = "${var.environment}"
   function            = "${var.name}"
+}
+
+data "template_cloudinit_config" "instances_userdata" {
+  count         = "${var.cluster_size}"
+  gzip          = true
+  base64_encode = true
+
+  # Format external volume as ext4
+  part {
+    content_type = "text/cloud-config"
+
+    content = <<EOF
+fs_setup:
+  - label: es_data
+    filesystem: 'ext4'
+    device: '${var.db_vl_name}'
+EOF
+  }
+
+  # Mount external volume
+  part {
+    content_type = "text/cloud-config"
+
+    content = <<EOF
+mounts:
+  - [ ${var.db_vl_name}, ${var.es_data_dir}, ext4, "defaults", "0", "2" ]
+EOF
+  }
+
+  # Bootstrap puppet
+  part {
+    content_type = "text/x-shellscript"
+    content      = "${module.elk_userdata.user_datas[count.index]}"
+  }
 }
 
 resource "aws_ebs_volume" "elk_volume" {

--- a/variables.tf
+++ b/variables.tf
@@ -95,3 +95,8 @@ variable "snapshot_s3_bucket_arn" {
   type    = "string"
   default = ""
 }
+
+variable "es_data_dir" {
+  type    = "string"
+  default = "/usr/share/elasticsearch/data/"
+}


### PR DESCRIPTION
I figured that it would be much cleaner to do the disk format and mounting from cloud-init, just before bootstrapping puppet.