### PR TITLE
Create the additional EBS volume in the instance module

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,10 @@ Terraform module to setup all resources needed for an Elasticsearch cluster.
 *   \[`instance_type`\]: String(optional, default "t2.small"): The instance type to launch for the Elasticsearch nodes.
 *   \[`termination_protection`\]: Bool(optional, default true): Whether to enable termination protection on the Elasticsearch nodes.
 *   \[`db_vl_type`\]: String(optional, default "gp2"): Type of the Elasticsearch data EBS volume.
+*   \[`db_vl_iops`\]: String(optional, default ""): The amount of provisioned IOPS. This is only valid for db_vl_type of "io1", and must be specified if using that type
 *   \[`db_vl_size`\]: Number(optional, default 100): Size in GB of the Elasticsearch data EBS volume.
 *   \[`db_vl_name`\]: String(optional, default "/dev/xvdg"): Volume device name of the Elasticsearch data EBS volume.
+*   \[`db_vl_encrypted`\]: String(optional, default "false"): Enables EBS encryption on the volume.
 *   \[`elb_internal`\]: Bool(optional, default true): Whether the ELB should be internal only (not-public).
 *   \[`snapshot_s3_bucket_arn`\]: String(optional, default ""): The S3 bucket ARN where the ES snapshots will be stored, this is just to give the proper permissions to the EC2 instance profiles.
 *   \[`es_data_dir`\]: String(optional, default "/usr/share/elasticsearch/data/"): The directory where to mount the external volume, so this will be the directory where Elasticsearch will store the data.

--- a/iam.tf
+++ b/iam.tf
@@ -7,7 +7,8 @@ resource "aws_iam_policy" "elk_instances_policy" {
   "Statement": [
     {
       "Action": [
-        "ec2:DescribeInstances"
+        "ec2:DescribeInstances",
+        "ec2:DescribeVolume*"
       ],
       "Effect": "Allow",
       "Resource": "*"

--- a/variables.tf
+++ b/variables.tf
@@ -65,6 +65,15 @@ variable "db_vl_type" {
   default = "gp2"
 }
 
+variable "db_vl_iops" {
+  default = 0
+}
+
+variable "db_vl_encrypted" {
+  type = "string"
+  default = "false"
+}
+
 variable "db_vl_size" {
   default = 100
 }
@@ -72,6 +81,11 @@ variable "db_vl_size" {
 variable "db_vl_name" {
   type    = "string"
   default = "/dev/xvdg"
+}
+
+variable "db_vl_delete_on_termination" {
+  type    = "string"
+  default = "true"
 }
 
 variable "elb_internal" {


### PR DESCRIPTION
We can't create the ebs volume separated from the instance because the volume is being attached and formatted after the instance cloud-init script is run, so it creates a race condition issue.

This PR depends on this one: https://github.com/skyscrapers/terraform-instances/pull/8