### PR TITLE
Separate the sg in on ELB for the different services

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Terraform module to setup all resources needed for an Elasticsearch cluster.
 
 *   \[`project`\]: String(required): The name of the project.
 *   \[`environment`\]: String(required): The name of the environment (production, staging , development).
-*   \[`elb_ingress_sgs`\]: List(required): List of Security Groups which need access to the cluster.
+*   \[`elb_es_ingress_sgs`\]: List(required): List of Security Groups which need access to the Elasticsearch port of the cluster.
 *   \[`vpc_id`\]: String(required): VPC ID where the proxies will be deployed.
 *   \[`subnet_ids`\]: List(required): Subnet IDs where the cluster will be deployed.
 *   \[`sg_all_id`\]: String(required): ID of the base security group.
@@ -20,6 +20,8 @@ Terraform module to setup all resources needed for an Elasticsearch cluster.
 *   \[`elasticsearch_java_port`\]: Number(optional, default 9300): Elasticsearch JAVA API port.
 *   \[`logstash_port`\]: Number(optional, default 9600): Logstash port.
 *   \[`kibana_port`\]: Number(optional, default 5601): Kibana port.
+*   \[`elb_kibana_ingress_sgs`\]: List(optional): List of Security Groups which need access to the Kibana port of the cluster.
+*   \[`elb_logstash_ingress_sgs`\]: List(optional): List of Security Groups which need access to the Logstash port of the cluster.
 *   \[`instance_type`\]: String(optional, default "t2.small"): The instance type to launch for the Elasticsearch nodes.
 *   \[`termination_protection`\]: Bool(optional, default true): Whether to enable termination protection on the Elasticsearch nodes.
 *   \[`db_vl_type`\]: String(optional, default "gp2"): Type of the Elasticsearch data EBS volume.
@@ -44,18 +46,18 @@ Terraform module to setup all resources needed for an Elasticsearch cluster.
 
 ```terraform
 module "elk_cluster" {
-  source           = "github.com/skyscrapers/terraform-elk_cluster?ref=1.0.0"
-  project          = "${var.project}"
-  environment      = "${var.environment}"
-  cluster_size     = 3
-  logstash_enabled = true
-  kibana_enabled   = true
-  ami              = "ami-6c101b0a"
-  instance_type    = "t2.small"
-  key_name         = "mykey"
-  vpc_id           = "${module.vpc.vpc_id}"
-  subnet_ids       = "${module.vpc.private_db_subnets}"
-  sg_all_id        = "${module.general_security_groups.sg_all_id}"
-  elb_ingress_sgs  = ["${module.app.sg_id}"]
+  source              = "github.com/skyscrapers/terraform-elk_cluster?ref=1.0.0"
+  project             = "${var.project}"
+  environment         = "${var.environment}"
+  cluster_size        = 3
+  logstash_enabled    = true
+  kibana_enabled      = true
+  ami                 = "ami-6c101b0a"
+  instance_type       = "t2.small"
+  key_name            = "mykey"
+  vpc_id              = "${module.vpc.vpc_id}"
+  subnet_ids          = "${module.vpc.private_db_subnets}"
+  sg_all_id           = "${module.general_security_groups.sg_all_id}"
+  elb_es_ingress_sgs  = ["${module.app.sg_id}"]
 }
 ```

--- a/sg.tf
+++ b/sg.tf
@@ -83,13 +83,13 @@ resource "aws_security_group_rule" "instance_ingress_kibana_from_elb" {
 ## ELB
 
 resource "aws_security_group_rule" "elb_ingress_es_from_outside" {
-  count                    = "${length(var.elb_ingress_sgs)}"
+  count                    = "${length(var.elb_es_ingress_sgs)}"
   type                     = "ingress"
   protocol                 = "tcp"
   from_port                = "${var.elasticsearch_port}"
   to_port                  = "${var.elasticsearch_port}"
   security_group_id        = "${aws_security_group.elk_elb_sg.id}"
-  source_security_group_id = "${element(var.elb_ingress_sgs, count.index)}"
+  source_security_group_id = "${element(var.elb_es_ingress_sgs, count.index)}"
 }
 
 resource "aws_security_group_rule" "elb_egress_es_to_instance" {
@@ -102,13 +102,13 @@ resource "aws_security_group_rule" "elb_egress_es_to_instance" {
 }
 
 resource "aws_security_group_rule" "elb_ingress_es-java_from_outside" {
-  count                    = "${length(var.elb_ingress_sgs)}"
+  count                    = "${length(var.elb_es_ingress_sgs)}"
   type                     = "ingress"
   protocol                 = "tcp"
   from_port                = "${var.elasticsearch_java_port}"
   to_port                  = "${var.elasticsearch_java_port}"
   security_group_id        = "${aws_security_group.elk_elb_sg.id}"
-  source_security_group_id = "${element(var.elb_ingress_sgs, count.index)}"
+  source_security_group_id = "${element(var.elb_es_ingress_sgs, count.index)}"
 }
 
 resource "aws_security_group_rule" "elb_egress_es-java_to_instance" {
@@ -121,13 +121,13 @@ resource "aws_security_group_rule" "elb_egress_es-java_to_instance" {
 }
 
 resource "aws_security_group_rule" "elb_ingress_logstash_from_outside" {
-  count                    = "${var.logstash_enabled ? length(var.elb_ingress_sgs) : 0}"
+  count                    = "${var.logstash_enabled ? length(var.elb_logstash_ingress_sgs) : 0}"
   type                     = "ingress"
   protocol                 = "tcp"
   from_port                = "${var.logstash_port}"
   to_port                  = "${var.logstash_port}"
   security_group_id        = "${aws_security_group.elk_elb_sg.id}"
-  source_security_group_id = "${element(var.elb_ingress_sgs, count.index)}"
+  source_security_group_id = "${element(var.elb_logstash_ingress_sgs, count.index)}"
 }
 
 resource "aws_security_group_rule" "elb_egress_logstash_to_instance" {
@@ -141,17 +141,17 @@ resource "aws_security_group_rule" "elb_egress_logstash_to_instance" {
 }
 
 resource "aws_security_group_rule" "elb_ingress_kibana_from_outside" {
-  count                    = "${var.kibana_enabled ? length(var.elb_ingress_sgs) : 0}"
+  count                    = "${var.kibana_enabled ? length(var.elb_kibana_ingress_sgs) : 0}"
   type                     = "ingress"
   protocol                 = "tcp"
   from_port                = "${var.kibana_port}"
   to_port                  = "${var.kibana_port}"
   security_group_id        = "${aws_security_group.elk_elb_sg.id}"
-  source_security_group_id = "${element(var.elb_ingress_sgs, count.index)}"
+  source_security_group_id = "${element(var.elb_kibana_ingress_sgs, count.index)}"
 }
 
 resource "aws_security_group_rule" "elb_egress_kibana_to_instance" {
-  count                    = "${var.logstash_enabled ? 1 : 0}"
+  count                    = "${var.kibana_enabled ? 1 : 0}"
   type                     = "egress"
   protocol                 = "tcp"
   from_port                = "${var.kibana_port}"

--- a/variables.tf
+++ b/variables.tf
@@ -115,9 +115,21 @@ variable "elb_internal" {
   description = "Whether the ELB should be internal only (not-public)."
 }
 
-variable "elb_ingress_sgs" {
+variable "elb_es_ingress_sgs" {
   type        = "list"
-  description = "List of Security Groups which need access to the cluster."
+  description = "List of Security Groups which need access to the Elasticsearch port of the cluster."
+}
+
+variable "elb_kibana_ingress_sgs" {
+  type        = "list"
+  default     = []
+  description = "List of Security Groups which need access to the Kibana port of the cluster."
+}
+
+variable "elb_logstash_ingress_sgs" {
+  type        = "list"
+  default     = []
+  description = "List of Security Groups which need access to the Logstash port of the cluster."
 }
 
 variable "sg_all_id" {


### PR DESCRIPTION
We have to divide the security groups in on the ELB for the different services. This is needed as not the same instances need access to all the services.