### PR TITLE
Do not create IAM roles and SG if no instances are created

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -1,7 +1,7 @@
 resource "aws_iam_policy" "elk_instances_policy" {
+  count       = "${var.cluster_size == "0" ? 0 : 1}"
   name        = "elk_instances_policy_${var.name}_${var.project}_${var.environment}"
   description = "Policy for the ELK instances of ${var.name} ${var.project} ${var.environment}"
-  count       = "${var.cluster_size == "0" ? 0 : 1}"
   policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -48,7 +48,7 @@ EOF
 }
 
 resource "aws_iam_role_policy_attachment" "elk_instances_policy_attachment" {
+  count      = "${var.cluster_size == "0" ? 0 : 1}"
   role       = "${module.elk_instances.role_id}"
   policy_arn = "${aws_iam_policy.elk_instances_policy.arn}"
-  count      = "${var.cluster_size == "0" ? 0 : 1}"
 }

--- a/iam.tf
+++ b/iam.tf
@@ -1,7 +1,7 @@
 resource "aws_iam_policy" "elk_instances_policy" {
   name        = "elk_instances_policy_${var.name}_${var.project}_${var.environment}"
   description = "Policy for the ELK instances of ${var.name} ${var.project} ${var.environment}"
-
+  count       = "${var.cluster_size == "0" ? 0 : 1}"
   policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -50,4 +50,5 @@ EOF
 resource "aws_iam_role_policy_attachment" "elk_instances_policy_attachment" {
   role       = "${module.elk_instances.role_id}"
   policy_arn = "${aws_iam_policy.elk_instances_policy.arn}"
+  count      = "${var.cluster_size == "0" ? 0 : 1}"
 }

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 module "elk_instances" {
-  source                 = "github.com/skyscrapers/terraform-instances//instance?ref=noCreateZero"
+  source                 = "github.com/skyscrapers/terraform-instances//instance?ref=21a85a47f7079bd0bb1aec94be454ef08f80608f"
   project                = "${var.project}"
   environment            = "${var.environment}"
   name                   = "${var.name}"

--- a/main.tf
+++ b/main.tf
@@ -71,8 +71,8 @@ variable "elb_listener_keys" {
 }
 
 resource "aws_elb" "elk_elb" {
-  name                      = "${var.name}-${var.project}-${var.environment}"
   count                     = "${var.cluster_size == "0" ? 0 : var.cluster_size}"
+  name                      = "${var.name}-${var.project}-${var.environment}"
   cross_zone_load_balancing = true
   connection_draining       = false
   security_groups           = ["${aws_security_group.elk_elb_sg.id}"]

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 module "elk_instances" {
-  source                 = "github.com/skyscrapers/terraform-instances//instance?ref=1.1.0"
+  source                 = "github.com/skyscrapers/terraform-instances//instance?ref=noCreateZero"
   project                = "${var.project}"
   environment            = "${var.environment}"
   name                   = "${var.name}"

--- a/main.tf
+++ b/main.tf
@@ -72,6 +72,7 @@ variable "elb_listener_keys" {
 
 resource "aws_elb" "elk_elb" {
   name                      = "${var.name}-${var.project}-${var.environment}"
+  count                     = "${var.cluster_size == "0" ? 0 : var.cluster_size}"
   cross_zone_load_balancing = true
   connection_draining       = false
   security_groups           = ["${aws_security_group.elk_elb_sg.id}"]

--- a/sg.tf
+++ b/sg.tf
@@ -89,7 +89,7 @@ resource "aws_security_group_rule" "instance_ingress_kibana_from_elb" {
 ## ELB
 
 resource "aws_security_group_rule" "elb_ingress_es_from_outside" {
-  count                    = "${length(var.elb_es_ingress_sgs)}"
+  count                    = "${var.cluster_size == "0" ? 0 : length(var.elb_es_ingress_sgs)}"
   type                     = "ingress"
   protocol                 = "tcp"
   from_port                = "${var.elasticsearch_port}"
@@ -109,7 +109,7 @@ resource "aws_security_group_rule" "elb_egress_es_to_instance" {
 }
 
 resource "aws_security_group_rule" "elb_ingress_es-java_from_outside" {
-  count                    = "${length(var.elb_es_ingress_sgs)}"
+  count                    = "${var.cluster_size == "0" ? 0 : length(var.elb_es_ingress_sgs)}"
   type                     = "ingress"
   protocol                 = "tcp"
   from_port                = "${var.elasticsearch_java_port}"

--- a/sg.tf
+++ b/sg.tf
@@ -1,6 +1,7 @@
 resource "aws_security_group" "elk_sg" {
   name        = "sg_${var.name}_${var.project}_${var.environment}"
   description = "Security group that is needed for the ELK cluster"
+  count       = "${var.cluster_size == "0" ? 0 : 1}"
   vpc_id      = "${var.vpc_id}"
 
   tags {
@@ -13,6 +14,7 @@ resource "aws_security_group" "elk_sg" {
 resource "aws_security_group" "elk_elb_sg" {
   name        = "sg_elb_${var.name}_${var.project}_${var.environment}"
   description = "Security group that is needed for the ELK cluster ELB"
+  count       = "${var.cluster_size == "0" ? 0 : 1}"
   vpc_id      = "${var.vpc_id}"
 
   tags {
@@ -25,6 +27,7 @@ resource "aws_security_group" "elk_elb_sg" {
 ## INSTANCES
 
 resource "aws_security_group_rule" "instance_ingress_cluster" {
+  count             = "${var.cluster_size == "0" ? 0 : 1}"
   type              = "ingress"
   from_port         = "${var.elasticsearch_java_port}"
   to_port           = "${var.elasticsearch_java_port}"
@@ -34,6 +37,7 @@ resource "aws_security_group_rule" "instance_ingress_cluster" {
 }
 
 resource "aws_security_group_rule" "instance_egress_cluster" {
+  count             = "${var.cluster_size == "0" ? 0 : 1}"
   type              = "egress"
   from_port         = "${var.elasticsearch_java_port}"
   to_port           = "${var.elasticsearch_java_port}"
@@ -43,6 +47,7 @@ resource "aws_security_group_rule" "instance_egress_cluster" {
 }
 
 resource "aws_security_group_rule" "instance_ingress_es_from_elb" {
+  count                   = "${var.cluster_size == "0" ? 0 : 1}"
   type                     = "ingress"
   protocol                 = "tcp"
   from_port                = "${var.elasticsearch_port}"
@@ -52,6 +57,7 @@ resource "aws_security_group_rule" "instance_ingress_es_from_elb" {
 }
 
 resource "aws_security_group_rule" "instance_ingress_es_java_from_elb" {
+  count                    = "${var.cluster_size == "0" ? 0 : 1}"
   type                     = "ingress"
   protocol                 = "tcp"
   from_port                = "${var.elasticsearch_java_port}"
@@ -93,6 +99,7 @@ resource "aws_security_group_rule" "elb_ingress_es_from_outside" {
 }
 
 resource "aws_security_group_rule" "elb_egress_es_to_instance" {
+  count                    = "${var.cluster_size == "0" ? 0 : 1}"
   type                     = "egress"
   protocol                 = "tcp"
   from_port                = "${var.elasticsearch_port}"
@@ -112,6 +119,7 @@ resource "aws_security_group_rule" "elb_ingress_es-java_from_outside" {
 }
 
 resource "aws_security_group_rule" "elb_egress_es-java_to_instance" {
+  count                    = "${var.cluster_size == "0" ? 0 : 1}"
   type                     = "egress"
   protocol                 = "tcp"
   from_port                = "${var.elasticsearch_java_port}"

--- a/sg.tf
+++ b/sg.tf
@@ -1,7 +1,7 @@
 resource "aws_security_group" "elk_sg" {
+  count       = "${var.cluster_size == "0" ? 0 : 1}"
   name        = "sg_${var.name}_${var.project}_${var.environment}"
   description = "Security group that is needed for the ELK cluster"
-  count       = "${var.cluster_size == "0" ? 0 : 1}"
   vpc_id      = "${var.vpc_id}"
 
   tags {
@@ -12,9 +12,9 @@ resource "aws_security_group" "elk_sg" {
 }
 
 resource "aws_security_group" "elk_elb_sg" {
+  count       = "${var.cluster_size == "0" ? 0 : 1}"
   name        = "sg_elb_${var.name}_${var.project}_${var.environment}"
   description = "Security group that is needed for the ELK cluster ELB"
-  count       = "${var.cluster_size == "0" ? 0 : 1}"
   vpc_id      = "${var.vpc_id}"
 
   tags {


### PR DESCRIPTION
For the moment, it is not possible to add a count to a terraform module.

When we do not want it to be created under a certain environment, we can now specify cluster_size to 0 and nothing will be created.