### PR TITLE
adding option to add cloudwatch permission to ELK nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Terraform module to setup all resources needed for an Elasticsearch cluster.
 * \[`elb_internal`\]: Bool(optional, default true): Whether the ELB should be internal only (not-public).
 * \[`snapshot_s3_bucket_arn`\]: String(optional, default ""): The S3 bucket ARN where the ES snapshots will be stored, this is just to give the proper permissions to the EC2 instance profiles.
 * \[`es_data_dir`\]: String(optional, default "/usr/share/elasticsearch/data/"): The directory where to mount the external volume, so this will be the directory where Elasticsearch will store the data.
+* \[`cloudwatch_logs`\]: Boolean(optional, default false): Sets cloudwatch logs permissions to the elk instances role if enabled.
 
 ## Output
 

--- a/iam.tf
+++ b/iam.tf
@@ -52,3 +52,29 @@ resource "aws_iam_role_policy_attachment" "elk_instances_policy_attachment" {
   role       = "${module.elk_instances.role_id}"
   policy_arn = "${aws_iam_policy.elk_instances_policy.arn}"
 }
+
+resource "aws_iam_policy" "cloudwatch_policy" {
+  count       = "${var.cloudwatch_logs ? 1 : 0}"
+  name        = "elk_instances_policy_${var.name}_${var.project}_${var.environment}"
+  policy      = "${data.aws_iam_policy_document.cloudwatch_logs_push.json}"
+}
+
+data "aws_iam_policy_document" "cloudwatch_logs_push" {
+  statement {
+      effect = "Allow"
+      actions = [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents",
+        "logs:DescribeLogGroups",
+        "logs:DescribeLogStreams"
+      ],
+      resources = ["*"]
+    }
+}
+
+resource "aws_iam_role_policy_attachment" "cloudwatch_policy" {
+  count       = "${var.cloudwatch_logs ? 1 : 0}"
+  role       = "${module.elk_instances.role_id}"
+  policy_arn = "${aws_iam_policy.cloudwatch_policy.arn}"
+}

--- a/main.tf
+++ b/main.tf
@@ -1,10 +1,9 @@
 module "elk_instances" {
-  source                 = "github.com/skyscrapers/terraform-instances//instance?ref=1.2.2"
+  source                 = "github.com/skyscrapers/terraform-instances//instance?ref=2.0.14"
   project                = "${var.project}"
   environment            = "${var.environment}"
   name                   = "${var.name}"
   instance_count         = "${var.cluster_size}"
-  ebs_optimized          = "${var.ebs_optimized}"
   termination_protection = "${var.termination_protection}"
   key_name               = "${var.key_name}"
   ami                    = "${var.ami}"
@@ -86,7 +85,7 @@ resource "aws_elb" "elk_elb" {
   name                      = "${var.name}-${var.project}-${var.environment}"
   cross_zone_load_balancing = true
   connection_draining       = false
-  security_groups           = ["${aws_security_group.elk_elb_sg.id}"]
+  security_groups           = ["${aws_security_group.elk_elb_sg.*.id}"]
   internal                  = "${var.elb_internal}"
   subnets                   = ["${var.subnet_ids}"]
   instances                 = ["${module.elk_instances.instance_ids}"]

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,17 +3,17 @@ output "sg_id" {
 }
 
 output "sg_elb_id" {
-  value = "${aws_security_group.elk_elb_sg.id}"
+  value = "${aws_security_group.elk_elb_sg.0.id}"
 }
 
 output "elb_id" {
-  value = "${aws_elb.elk_elb.id}"
+  value = "${aws_elb.elk_elb.0.id}"
 }
 
 output "elb_dns_name" {
-  value = "${aws_elb.elk_elb.dns_name}"
+  value = "${aws_elb.elk_elb.0.dns_name}"
 }
 
 output "elb_zone_id" {
-  value = "${aws_elb.elk_elb.zone_id}"
+  value = "${aws_elb.elk_elb.0.zone_id}"
 }

--- a/sg.tf
+++ b/sg.tf
@@ -52,7 +52,7 @@ resource "aws_security_group_rule" "instance_ingress_es_from_elb" {
   from_port                = "${var.elasticsearch_port}"
   to_port                  = "${var.elasticsearch_port}"
   security_group_id        = "${aws_security_group.elk_sg.id}"
-  source_security_group_id = "${aws_security_group.elk_elb_sg.id}"
+  source_security_group_id = "${aws_security_group.elk_elb_sg.0.id}"
 }
 
 resource "aws_security_group_rule" "instance_ingress_es_java_from_elb" {
@@ -62,7 +62,7 @@ resource "aws_security_group_rule" "instance_ingress_es_java_from_elb" {
   from_port                = "${var.elasticsearch_java_port}"
   to_port                  = "${var.elasticsearch_java_port}"
   security_group_id        = "${aws_security_group.elk_sg.id}"
-  source_security_group_id = "${aws_security_group.elk_elb_sg.id}"
+  source_security_group_id = "${aws_security_group.elk_elb_sg.0.id}"
 }
 
 resource "aws_security_group_rule" "instance_ingress_logstash_from_elb" {
@@ -72,7 +72,7 @@ resource "aws_security_group_rule" "instance_ingress_logstash_from_elb" {
   from_port                = "${var.logstash_port}"
   to_port                  = "${var.logstash_port}"
   security_group_id        = "${aws_security_group.elk_sg.id}"
-  source_security_group_id = "${aws_security_group.elk_elb_sg.id}"
+  source_security_group_id = "${aws_security_group.elk_elb_sg.0.id}"
 }
 
 resource "aws_security_group_rule" "instance_ingress_kibana_from_elb" {
@@ -82,7 +82,7 @@ resource "aws_security_group_rule" "instance_ingress_kibana_from_elb" {
   from_port                = "${var.kibana_port}"
   to_port                  = "${var.kibana_port}"
   security_group_id        = "${aws_security_group.elk_sg.id}"
-  source_security_group_id = "${aws_security_group.elk_elb_sg.id}"
+  source_security_group_id = "${aws_security_group.elk_elb_sg.0.id}"
 }
 
 ## ELB
@@ -93,7 +93,7 @@ resource "aws_security_group_rule" "elb_ingress_es_from_outside" {
   protocol                 = "tcp"
   from_port                = "${var.elasticsearch_port}"
   to_port                  = "${var.elasticsearch_port}"
-  security_group_id        = "${aws_security_group.elk_elb_sg.id}"
+  security_group_id        = "${aws_security_group.elk_elb_sg.0.id}"
   source_security_group_id = "${element(var.elb_es_ingress_sgs, count.index)}"
 }
 
@@ -103,7 +103,7 @@ resource "aws_security_group_rule" "elb_egress_es_to_instance" {
   protocol                 = "tcp"
   from_port                = "${var.elasticsearch_port}"
   to_port                  = "${var.elasticsearch_port}"
-  security_group_id        = "${aws_security_group.elk_elb_sg.id}"
+  security_group_id        = "${aws_security_group.elk_elb_sg.0.id}"
   source_security_group_id = "${aws_security_group.elk_sg.id}"
 }
 
@@ -113,7 +113,7 @@ resource "aws_security_group_rule" "elb_ingress_es-java_from_outside" {
   protocol                 = "tcp"
   from_port                = "${var.elasticsearch_java_port}"
   to_port                  = "${var.elasticsearch_java_port}"
-  security_group_id        = "${aws_security_group.elk_elb_sg.id}"
+  security_group_id        = "${aws_security_group.elk_elb_sg.0.id}"
   source_security_group_id = "${element(var.elb_es_ingress_sgs, count.index)}"
 }
 
@@ -123,7 +123,7 @@ resource "aws_security_group_rule" "elb_egress_es-java_to_instance" {
   protocol                 = "tcp"
   from_port                = "${var.elasticsearch_java_port}"
   to_port                  = "${var.elasticsearch_java_port}"
-  security_group_id        = "${aws_security_group.elk_elb_sg.id}"
+  security_group_id        = "${aws_security_group.elk_elb_sg.0.id}"
   source_security_group_id = "${aws_security_group.elk_sg.id}"
 }
 
@@ -133,7 +133,7 @@ resource "aws_security_group_rule" "elb_ingress_logstash_from_outside" {
   protocol                 = "tcp"
   from_port                = "${var.logstash_port}"
   to_port                  = "${var.logstash_port}"
-  security_group_id        = "${aws_security_group.elk_elb_sg.id}"
+  security_group_id        = "${aws_security_group.elk_elb_sg.0.id}"
   source_security_group_id = "${element(var.elb_logstash_ingress_sgs, count.index)}"
 }
 
@@ -143,7 +143,7 @@ resource "aws_security_group_rule" "elb_egress_logstash_to_instance" {
   protocol                 = "tcp"
   from_port                = "${var.logstash_port}"
   to_port                  = "${var.logstash_port}"
-  security_group_id        = "${aws_security_group.elk_elb_sg.id}"
+  security_group_id        = "${aws_security_group.elk_elb_sg.0.id}"
   source_security_group_id = "${aws_security_group.elk_sg.id}"
 }
 
@@ -153,7 +153,7 @@ resource "aws_security_group_rule" "elb_ingress_kibana_from_outside" {
   protocol                 = "tcp"
   from_port                = "${var.kibana_port}"
   to_port                  = "${var.kibana_port}"
-  security_group_id        = "${aws_security_group.elk_elb_sg.id}"
+  security_group_id        = "${aws_security_group.elk_elb_sg.0.id}"
   source_security_group_id = "${element(var.elb_kibana_ingress_sgs, count.index)}"
 }
 
@@ -163,6 +163,6 @@ resource "aws_security_group_rule" "elb_egress_kibana_to_instance" {
   protocol                 = "tcp"
   from_port                = "${var.kibana_port}"
   to_port                  = "${var.kibana_port}"
-  security_group_id        = "${aws_security_group.elk_elb_sg.id}"
+  security_group_id        = "${aws_security_group.elk_elb_sg.0.id}"
   source_security_group_id = "${aws_security_group.elk_sg.id}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -60,11 +60,6 @@ variable "instance_type" {
   description = "The instance type to launch for the Elasticsearch nodes."
 }
 
-variable "ebs_optimized" {
-  description = "Whether to enable EBS optimization. You need to set this according the used instance type."
-  default     = false
-}
-
 variable "key_name" {
   type        = "string"
   description = "ID of the SSH key to use for the Elasticsearch nodes."
@@ -161,4 +156,9 @@ variable "es_data_dir" {
 variable "customer" {
   description = "The name of the customer"
   default = ""
+}
+
+variable "cloudwatch_logs" {
+  description = "Sets cloudwatch logs permissions to the elk instances role if enabled"
+  default = false
 }


### PR DESCRIPTION
Ths PR add the option to send cloudwatch logs for the ELK nodes and fixes some compatibility issues with terraform 0.11